### PR TITLE
Fix Rails 6.2 `ActiveModel::Errors #[]=` deprecation

### DIFF
--- a/lib/state_validations/state_history_entry_validator.rb
+++ b/lib/state_validations/state_history_entry_validator.rb
@@ -23,7 +23,7 @@ module ActiveModel
         start = record[@start]
         _end  = record[@end]
         if start == _end
-          record.errors[:base] << "Start time (#{start}) is equal to end (#{_end})"
+          record.errors.add(:base, "Start time (#{start}) is equal to end (#{_end})")
         end
       end
 
@@ -31,7 +31,7 @@ module ActiveModel
         start = record[@start]
         _end  = record[@end]
         if !_end.blank? && start > _end
-          record.errors[:base] << "Start time (#{start}) is later than end time (#{_end})"
+          record.errors.add(:base, "Start time (#{start}) is later than end time (#{_end})")
         end
       end
     end

--- a/lib/state_validations/state_history_validator.rb
+++ b/lib/state_validations/state_history_validator.rb
@@ -56,7 +56,7 @@ module ActiveModel
         last = history.last
 
         if !last[@end].nil?
-          errors[:base] << "no nil ending"
+          errors.add(:base, "no nil ending")
           return false
         end
 
@@ -65,7 +65,7 @@ module ActiveModel
 
       def no_self_transitions?(this_entry, next_entry, errors)
         if matches?(this_entry, next_entry) && this_entry[@end] == next_entry[@start]
-          errors[:base] << "self-transition found"
+          errors.add(:base, "self-transition found")
           return false
         end
 
@@ -74,7 +74,7 @@ module ActiveModel
 
       def no_gaps?(this_entry, next_entry, errors)
         if !this_entry[@end].nil? && next_entry[@start] > this_entry[@end]
-          errors[:base] << "Gap found"
+          errors.add(:base, "Gap found")
           return false
         end
 
@@ -83,7 +83,7 @@ module ActiveModel
 
       def no_overlaps?(this_entry, next_entry, errors)
         if !this_entry[@end].nil? && next_entry[@start] < this_entry[@end]
-          errors[:base] << "Overlap found"
+          errors.add(:base, "Overlap found")
           return false
         end
 
@@ -93,7 +93,7 @@ module ActiveModel
       # This doesn't get invoked on the very last entry, so we should be safe
       def no_intervening_nils?(this_entry, errors)
         if this_entry[@end].blank?
-          errors[:base] << "Found nil end in middle of state history"
+          errors.add(:base, "Found nil end in middle of state history")
           return false
         end
 


### PR DESCRIPTION
Pretty simple fix